### PR TITLE
Remove the API call to /account

### DIFF
--- a/lib/omniauth/strategies/heroku.rb
+++ b/lib/omniauth/strategies/heroku.rb
@@ -10,25 +10,6 @@ module OmniAuth
         :authorize_url => "#{BaseAuthUrl}/oauth/authorize",
         :token_url => "#{BaseAuthUrl}/oauth/token"
       }
-
-      def request_phase
-        super
-      end
-
-      uid { raw_info['id'] }
-
-      info do
-        { 'email' => raw_info['email'] }
-      end
-
-      extra do
-        { 'raw_info' => raw_info }
-      end
-
-      def raw_info
-        access_token.options[:mode] = :header
-        @raw_info ||= access_token.get('/account').parsed
-      end
     end
   end
 end


### PR DESCRIPTION
The commit included removes it entirely, but I'll admit that perhaps a better strategy would be to make it optional.
