### PR TITLE
Update omniauth-oauth2 to 1.1.1

### DIFF
--- a/omniauth-heroku.gemspec
+++ b/omniauth-heroku.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split("\n")
   gem.name          = "omniauth-heroku"
   gem.require_paths = ["lib"]
-  gem.version       = "0.1.1"
+  gem.version       = "0.1.2"
 
   gem.add_dependency 'omniauth', '~> 1.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1.1'


### PR DESCRIPTION
Doesn't look like a critical upgrade, but we've been using this fork on production for a few weeks and haven't found any problem.
