### PR TITLE
Render error when client id or secret are not set

### DIFF
--- a/lib/omniauth/strategies/heroku.rb
+++ b/lib/omniauth/strategies/heroku.rb
@@ -44,6 +44,18 @@ module OmniAuth
         end
       end
 
+      # override method in OmniAuth::Strategies::OAuth2 to error
+      # when we don't have a client_id or secret:
+      def request_phase
+        if missing_client_id?
+          fail!(:missing_client_id)
+        elsif missing_client_secret?
+          fail!(:missing_client_secret)
+        else
+          super
+        end
+      end
+
       def account_info
         @account_info ||= MultiJson.decode(heroku_api.get("/account").body)
       end
@@ -55,6 +67,14 @@ module OmniAuth
             "Accept" => "application/vnd.heroku+json; version=3",
             "Authorization" => "Bearer #{access_token.token}",
           })
+      end
+
+      def missing_client_id?
+        [nil, ""].include?(options.client_id)
+      end
+
+      def missing_client_secret?
+        [nil, ""].include?(options.client_secret)
       end
     end
   end

--- a/spec/omniauth_heroku_spec.rb
+++ b/spec/omniauth_heroku_spec.rb
@@ -68,4 +68,22 @@ describe OmniAuth::Strategies::Heroku do
     assert_equal "John", omniauth_env["info"]["name"]
     assert_equal account_info, omniauth_env["extra"]
   end
+
+  describe "error handling" do
+    it "renders an error when client_id is not informed" do
+      @app = make_app(client_id: nil)
+      get "/auth/heroku"
+      assert_equal 302, last_response.status
+      redirect = URI.parse(last_response.headers["Location"])
+      assert_equal "/auth/failure", redirect.path
+    end
+
+    it "renders an error when client_secret is not informed" do
+      @app = make_app(client_secret: "") # should also handle empty strings
+      get "/auth/heroku"
+      assert_equal 302, last_response.status
+      redirect = URI.parse(last_response.headers["Location"])
+      assert_equal "/auth/failure", redirect.path
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,15 @@ RSpec.configure do |config|
   end
 
   def make_app(omniauth_heroku_options={})
+    client_id     = ENV["HEROKU_OAUTH_ID"]
+    client_secret = ENV["HEROKU_OAUTH_SECRET"]
+    if omniauth_heroku_options.has_key?(:client_id)
+      client_id = omniauth_heroku_options.delete(:client_id)
+    end
+    if omniauth_heroku_options.has_key?(:client_secret)
+      client_secret = omniauth_heroku_options.delete(:client_secret)
+    end
+
     Sinatra.new do
       configure do
         enable :sessions
@@ -36,8 +45,7 @@ RSpec.configure do |config|
       end
 
       use OmniAuth::Builder do
-        provider :heroku, ENV["HEROKU_OAUTH_ID"], ENV["HEROKU_OAUTH_SECRET"],
-          omniauth_heroku_options
+        provider :heroku, client_id, client_secret, omniauth_heroku_options
       end
 
       get "/auth/heroku/callback" do


### PR DESCRIPTION
When a nil or empty client id/secret is provided, omniauth-oauth2 will still try to perform the callback normally, causing issues that are confusing/hard to debug.

See #14.
