### PR TITLE
Allow dynamic oauth scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ end
 This will trim down the permissions associated to the access token given back
 to you.
 
+The Oauth scope can also be decided dynamically at runtime. For example, you could use a `scope` GET parameter if it exists, and revert to a default `scope` if it does not:
+
+```ruby
+use OmniAuth::Builder do
+  provider :heroku, ENV['HEROKU_OAUTH_ID'], ENV['HEROKU_OAUTH_SECRET'],
+    scope: lambda { |request| request.params['scope'] || 'identity' }
+end
+```
+
 
 ## Example - Sinatra
 

--- a/lib/omniauth/strategies/heroku.rb
+++ b/lib/omniauth/strategies/heroku.rb
@@ -56,6 +56,15 @@ module OmniAuth
         end
       end
 
+      def authorize_params
+        super.tap do |params|
+          # Allow the scope to be determined dynamically based on the request.
+          if params.scope.respond_to?(:call)
+            params.scope = params.scope.call(request)
+          end
+        end
+      end
+
       def account_info
         @account_info ||= MultiJson.decode(heroku_api.get("/account").body)
       end


### PR DESCRIPTION
This allows a lambda to be passed as the Oauth `scope`, so that it can be determined dynamically at runtime. The use-case for this is being able to ask for different permissions within my app, depending on the needs of the user, for example:

```ruby
use OmniAuth::Builder do
  provider :heroku, ENV['HEROKU_OAUTH_ID'], ENV['HEROKU_OAUTH_SECRET'],
    scope: lambda { |request| request.params['scope'] }
end
```
