### PR TITLE
Point to newer platform-api gem in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ refresh token and an access token (identified just as `"token"`) to the
 account.
 
 We recommend using this access token together with
-[Heroku.rb][heroku-ruby-client] to make API calls on behalf of the user.
+the [Heroku Platform API gem][heroku-ruby-client] to make API calls on behalf of the user.
 
-[heroku-ruby-client]: https://github.com/heroku/heroku.rb
+[heroku-ruby-client]: https://github.com/heroku/platform-api
 
 Refer to the examples below to see how these work.
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ class Myapp < Sinatra::Application
     access_token = env["omniauth.auth"]["credentials"]["token"]
     # DO NOT store this token in an unencrypted cookie session
     # Please read "A note on security" below!
-    heroku_api = Heroku::API.new(api_key: access_token)
-    "You have #{heroku_api.get_apps.body.size} apps"
+    heroku = PlatformAPI.connect_oauth(access_token)
+    "You have #{heroku.app.list.count} apps"
   end
 end
 ```
@@ -166,8 +166,8 @@ class SessionsController < ApplicationController
     access_token = request.env['omniauth.auth']['credentials']['token']
     # DO NOT store this token in an unencrypted cookie session
     # Please read "A note on security" below!
-    heroku_api = Heroku::API.new(api_key: access_token)
-    @apps = heroku_api.get_apps.body
+    heroku = PlatformAPI.connect_oauth(access_token)
+    @apps = heroku.app.list
   end
 end
 ```


### PR DESCRIPTION
The heroku.rb gem is deprecated. We use the code-generated platform-api gem now. 

This also updates examples in README to use the platform-api gem.