### PR TITLE
Lock on older omniauth oauth2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, 3.0 ]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+    - name: Build and test
+      run: bundle exec rake spec
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,17 +1,16 @@
-*.gem
-*.rbc
-.bundle
-.config
-.yardoc
-Gemfile.lock
-InstalledFiles
-_yardoc
-coverage
-doc/
-lib/bundler/man
-/pkg
-rdoc
-spec/reports
-test/tmp
-test/version_tmp
-tmp
+# Ignore all logfiles and tempfiles
+/coverage/
+/log/
+/spec/reports
+/tmp/
+/tags
+
+# Package and dependency caches
+/.bundle
+/Gemfile.lock
+/pkg/
+
+# Generated documentation
+/doc/
+/.yardoc
+/_yardoc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-cache: bundler
-sudo: false
-rvm:
-  - 2.7
-  - 2.6
-  - 2.5
-  - 2.4
-  - 2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1] 2021-07-06
+
+### Changed
+- Lock to `omniauth-oauth2 ~> 1.6.0` to fix regression in dynamic `scope:` option.
+  The following is broken in `omniauth-oauth2 >= 1.7.0` which will pass along the Rack `env` as the block parameter.
+
+  ```ruby
+  use OmniAuth::Builder do
+    provider :heroku, ENV.fetch("HEROKU_OAUTH_ID"), ENV.fetch("HEROKU_OAUTH_SECRET"),
+      scope: ->(request) { request.params["scope"] || "identity" }
+  end
+  ```
+
+  This results in an error because `#params` is not a method of `Hash`.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # OmniAuth Heroku
 
-[![Build Status](https://travis-ci.org/heroku/omniauth-heroku.svg?branch=master)](https://travis-ci.org/heroku/omniauth-heroku)
-
+[![Build Status](https://github.com/heroku/omniauth-heroku/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/omniauth-heroku/actions)
 
 [OmniAuth](https://github.com/intridea/omniauth) strategy for authenticating
 Heroku users.

--- a/omniauth-heroku.gemspec
+++ b/omniauth-heroku.gemspec
@@ -9,8 +9,19 @@ Gem::Specification.new do |gem|
 
   gem.files         = Dir["README.md", "LICENSE", "lib/**/*"]
   gem.require_path  = "lib"
-  gem.version       = "0.4.0"
+  gem.version       = "0.4.1"
 
   gem.add_dependency "omniauth", "~> 1.9.0"
-  gem.add_dependency "omniauth-oauth2", "~> 1.6"
+  # omniauth-oauth2 made a change in 1.7.0 which breaks our expectation
+  # you can use a block accepting a Rack::Request object as the argument
+  # to dynmically determine the `:scope` option. i.e., this broken:
+  #
+  # use OmniAuth::Builder do
+  #   provider :heroku, ENV.fetch("HEROKU_OAUTH_ID"), ENV.fetch("HEROKU_OAUTH_SECRET"),
+  #     scope: ->(request) { request.params["scope"] || "identity" }
+  # end
+  #
+  # We'll lock down the allowed version, cut a point release, and then
+  # release the lock in a new minor release.
+  gem.add_dependency "omniauth-oauth2", "~> 1.6.0"
 end


### PR DESCRIPTION
`omniauth-oauth2` made [a change in `1.7.0`](https://github.com/omniauth/omniauth-oauth2/pull/97) which breaks our expectation you can use a block accepting a `Rack::Request` object as the argument to dynamically determine the `:scope` option. i.e., this broken:

```ruby
  use OmniAuth::Builder do
    provider :heroku, ENV.fetch("HEROKU_OAUTH_ID"), ENV.fetch("HEROKU_OAUTH_SECRET"),
      scope: ->(request) { request.params["scope"] || "identity" }
  end
```

The breaking change is that now `omniauth-oauth2` will execute the block before our `OmniAuth::Strategies::Heroku` doesn't get the chance to do so. And when it executes the block, it passes in the Rack `env`. This breaks the contract of how `omniauth-heroku` since version `0.3.0` (released like 6 years ago).

One way to work around this is to adjust the blocks being passed to wrap the `env` in a new `Rack::Request`:

```ruby
scope: ->(env) { Rack::Request.new(env).params["scope"] || "identity" }
```

But for consumers of this gem, their existing code is still going to suddenly break. To help reduce that friction, the plan is to lock down the allowed version of the `omniauth-oauth2` dependency to ensure the old behavior. Then we'll cut a point release (`0.4.1`) of this gem, `omniauth-heroku`. Then we can update the README, examples, and CHANGELOG to announce a breaking change to this gem, open up the allowed version of the dependency, and cut a new version of this gem. Maybe even `1.0.0`, seeing as it's both breaking, and the thing has been used in production for half a decade.
