### PR TITLE
Remove superfluous method override

### DIFF
--- a/spec/omniauth/strategies/heroku_spec.rb
+++ b/spec/omniauth/strategies/heroku_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe OmniAuth::Strategies::Heroku do
       expect(strategy.authorize_params).not_to have_key("scope")
     end
 
-    it "can use a staic :scope" do
+    it "can use a static :scope option" do
       strategy = described_class.new(app, "OAuthId", "OAuthSecret", scope: "boring-scope")
 
       expect(strategy.authorize_params.fetch("scope")).to eq("boring-scope")


### PR DESCRIPTION
As of 3794d51b1030118785c294dd21d8586ba96c0744 we depend on the behavior of OmniAuth-OAuth2 1.7+ which will evaluate options given as blocks for us. This means by the time we get to this code, the `scope` is no longer a block, and doesn't respond to `#call`; we'll always `super` and then do nothing. Meaning we no longer need this override.