### PR TITLE
Use built-in JSON library

### DIFF
--- a/lib/omniauth/strategies/heroku.rb
+++ b/lib/omniauth/strategies/heroku.rb
@@ -69,7 +69,7 @@ module OmniAuth
       private_constant :DEFAULT_IMAGE_URL
 
       def account_info
-        @account_info ||= MultiJson.decode(heroku_api.get("/account").body)
+        @account_info ||= JSON.parse(heroku_api.get("/account").body)
       end
 
       def api_url

--- a/omniauth-heroku.gemspec
+++ b/omniauth-heroku.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency("omniauth", [">= 1.9", "< 3"])
   spec.add_runtime_dependency("omniauth-oauth2", "~> 1.7")
 
-  spec.add_development_dependency("multi_json", "~> 1.12")
   spec.add_development_dependency("rake", "~> 13.0")
   spec.add_development_dependency("rspec", "~> 3.4")
   spec.add_development_dependency("webmock", "~> 3.13")

--- a/spec/omniauth/strategies/heroku_spec.rb
+++ b/spec/omniauth/strategies/heroku_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe OmniAuth::Strategies::Heroku do
 
       stub_request(:get, "https://api.heroku.com/account")
         .with(headers: {"Authorization" => "Bearer #{token}"})
-        .to_return(body: MultiJson.encode(account_info))
+        .to_return(body: JSON.generate(account_info))
 
       expect(strategy.extra).to include(account_info)
     end
@@ -83,7 +83,7 @@ RSpec.describe OmniAuth::Strategies::Heroku do
 
       stub_request(:get, "https://api.heroku.com/account")
         .with(headers: {"Authorization" => "Bearer #{token}"})
-        .to_return(body: MultiJson.encode(account_info))
+        .to_return(body: JSON.generate(account_info))
 
       aggregate_failures do
         expect(strategy.info).to include(name: "John", email: "john@example.org")


### PR DESCRIPTION
MultiJSON is specified as a development dependency but also used at runtime.

There is no meaningful reason to introduce a dependency on MultiJSON to parse the API response body. The built-in JSON library can do that.