### PR TITLE
Test against maintained Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ 2.3, 2.4, 2.5, 2.6, 2.7, 3.0 ]
+        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
         gemfile: ["omniauth1", "omniauth2"]
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: ['4.0', '3.4', '3.3']
         gemfile: ["omniauth1", "omniauth2"]
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['4.0', '3.4', '3.3']
+        ruby: ['head', '4.0', '3.4', '3.3']
         gemfile: ["omniauth1", "omniauth2"]
+
+    continue-on-error: ${{ matrix.ruby == 'head' }}
 
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: Gemfile-${{ matrix.gemfile }}


### PR DESCRIPTION
We want to update the Ruby version matrix to cover [the actually maintained versions](https://www.ruby-lang.org/en/downloads/branches/).

#27 and #28 should be merged first for compatibility with the latest versions.